### PR TITLE
feat(transaction): add and generate UUID for transaction

### DIFF
--- a/src/components/createTransaction.vue
+++ b/src/components/createTransaction.vue
@@ -46,6 +46,7 @@
 
 <script lang="ts">
 import { defineComponent } from "vue";
+import { mapActions } from "vuex";
 import store, { Transaction } from "@/store/index";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
@@ -67,6 +68,7 @@ export default defineComponent({
         label: "",
         date: "",
         amount: 0,
+        id: "",
       },
     };
   },
@@ -78,18 +80,21 @@ export default defineComponent({
     },
   },
   methods: {
-    handleSubmit(): void {
+    ...mapActions(["generateUniqueId"]),
+    async handleSubmit(): Promise<void> {
       if (
         this.transaction.label &&
         this.transaction.date &&
         this.transaction.amount
       ) {
+        this.transaction.id = await this.generateUniqueId();
         store.commit("addTransaction", this.transaction);
         this.saveTransactionsToLocalstorage;
         this.transaction = {
           label: "",
           date: "",
           amount: 0,
+          id: "",
         };
         this.showError = false;
       } else {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -8,6 +8,7 @@ export interface Transaction {
   label: string;
   date: Date;
   amount: number;
+  id: string;
 }
 
 export interface Revenue {
@@ -60,9 +61,9 @@ const store = createStore({
       );
       state.transactions[index] = updatedTransaction;
     },
-    deleteTransaction(state, label: string) {
+    deleteTransaction(state, id: string) {
       state.transactions = state.transactions.filter(
-        (transaction) => transaction.label !== label
+        (transaction) => transaction.id !== id
       );
     },
     // Methods about Revenues
@@ -94,6 +95,12 @@ const store = createStore({
         localStorage.getItem("revenues") || "[]"
       );
       commit("setRevenues", revenues); // commit des Revenues récupérés
+    },
+    // Génère un ID
+    generateUniqueId(): string {
+      const timestamp = Date.now();
+      const random = Math.floor(Math.random() * 1000);
+      return `${timestamp}-${random}`;
     },
   },
   modules: {},

--- a/src/views/TransactionsList.vue
+++ b/src/views/TransactionsList.vue
@@ -21,7 +21,7 @@
             <button
               class="remove"
               :class="{ hover: hover }"
-              @click="deleteTransaction(transaction.label)"
+              @click="deleteTransaction(transaction.id)"
               @mouseover="hover = true"
               @mouseleave="hover = false"
             >
@@ -65,8 +65,8 @@ export default {
     ...mapGetters(["formattedTransactions"]),
   },
   methods: {
-    deleteTransaction(label: string): void {
-      store.commit("deleteTransaction", label);
+    deleteTransaction(id: string): void {
+      store.commit("deleteTransaction", id);
       this.saveTransactionsToLocalstorage();
     },
     saveTransactionsToLocalstorage() {


### PR DESCRIPTION
- Add id property to Transaction
- Create generateUniqueId() to generate UUID base on timetamps + random number (0 - 1000 range)
- Update deleteTransaction() to base based on id and no longer on label to prevent double deletion if transaction have same label.